### PR TITLE
Revert "pc.md - updated docs now that .zip files are supported"

### DIFF
--- a/docs/systems/pc.md
+++ b/docs/systems/pc.md
@@ -3,7 +3,7 @@
 
 | Game Path | Supported Extensions |
 | --- | --- |
-| `roms/pc` | ++".com"++ ++".bat"++ ++".exe"++ ++".dosz"++ ++".zip"++ |
+| `roms/pc` | ++".com"++ ++".bat"++ ++".exe"++ ++".dosz"++ |
 
 ## Emulator/Core
 
@@ -11,16 +11,3 @@
 | --- | --- |
 | dosbox_pure &nbsp; `default` | [docs.libretro.com/library/dosbox_pure](https://docs.libretro.com/library/dosbox_pure/) |
 | dosbox_svn | [docs.libretro.com/library/dosbox](https://docs.libretro.com/library/dosbox/) |
-
-## Notes
-
-If you are using the dosbox_pure core with `.dosz` or `.zip` roms, it will create libretro saves in the `roms/pc` directory with a `.pure.zip` extension. These save files capture changes to the original archive.
-
-The `.pure.zip` files will appear in the EmulationStation game list. To prevent this, and store these in `/storage/roms/savestates/pc` instead, create a content directory override in `/storage/.config/retroarch/config/DOSBox-pure/pc.cfg` with content:
-
-```
-savefiles_in_content_dir = "false"
-savefile_directory = "/storage/roms/savestates/pc"
-```
-
-After creating this content directory override, move any existing `.pure.zip` files into `/storage/roms/savestates/pc`.


### PR DESCRIPTION
Reverts ROCKNIX/rocknix.org#20

@anthonycaccese very sorry for the inconvenience, forgot I had this PR still open. Please revert the doco change as .zip files are not currently supported for PC system.