### PR TITLE
S922X global hotkeys

### DIFF
--- a/docs/devices/hardkernel/odroid-go-ultra.md
+++ b/docs/devices/hardkernel/odroid-go-ultra.md
@@ -37,7 +37,7 @@
 {%include 'controls/hypseus-singe.md' %}
 {%include 'controls/openbor.md' %}
 {%include 'controls/vice.md' %}
-{%set btn_hotkey_b = 'F2' %}
+{%set btn_hotkey_b = 'Start' %}
 {%include 'controls/extra.md' %}
 
 ## Notes

--- a/docs/devices/powkiddy/rgb10-max-3-pro.md
+++ b/docs/devices/powkiddy/rgb10-max-3-pro.md
@@ -37,7 +37,7 @@
 {%include 'controls/hypseus-singe.md' %}
 {%include 'controls/openbor.md' %}
 {%include 'controls/vice.md' %}
-{%set btn_hotkey_b = 'F2' %}
+{%set btn_hotkey_b = 'Start' %}
 {%include 'controls/extra.md' %}
 
 ## Notes

--- a/includes/controls/extra.md
+++ b/includes/controls/extra.md
@@ -12,5 +12,7 @@
 | ++"L1"+"START"+"SELECT"++ | Exit Emulator / Application |
 | ++"{{ btn_hotkey_a }}"+"Vol \+"++ | Brightness Up |
 | ++"{{ btn_hotkey_a }}"+"Vol -"++ | Brightness Down |
-| ++"{{ btn_hotkey_b }}"+"Vol \+"++ | Battery Status |
-| ++"{{ btn_hotkey_b }}"+"Vol -"++ | WIFI Toggle |
+| ++"{{ btn_hotkey_b }}"+"Vol \+"++ | LED on |
+| ++"{{ btn_hotkey_b }}"+"Vol -"++ | LED off |
+| ++"{{ btn_hotkey_a }}"+"{{ btn_hotkey_b }}"+"Vol \+"++ | WIFI enable |
+| ++"{{ btn_hotkey_a }}"+"{{ btn_hotkey_b }}"+"Vol -"++ | WIFI disable |


### PR DESCRIPTION
Looking at the `input_sense` script here: https://github.com/ROCKNIX/distribution/blob/e158bf47dc07adb4dd796a2a3e3b9a878833d995/packages/sysutils/system-utils/sources/scripts/input_sense#L102

The currently documented global hotkeys don't match up. So fixing these, and updating the hotkey A / B values for S922X so global hotkey show correctly on the wiki.