### PR TITLE
r36 pages: fix importpanel.py script args

### DIFF
--- a/docs/devices/unbranded/game-console-r35s-r36s.md
+++ b/docs/devices/unbranded/game-console-r35s-r36s.md
@@ -51,7 +51,7 @@ Assuming you have an [SSH](/faqs/#how-do-i-log-in-over-ssh-or-samba) access and 
 RK3326:~ # mount -o remount,rw /flash
 RK3326:~ # mkdir -p /flash/overlays/
 RK3326:~ # ### Be not afraid! importpanel.py may run for a minute or two for some panels
-RK3326:~ # /usr/libexec/generic-dsi/importpanel.py rk3326-r35s-linux.dtb -O /flash/overlays/mipi-panel.dtbo
+RK3326:~ # /usr/libexec/generic-dsi/importpanel.py rk3326-r35s-linux.dtb -O dtbo -o /flash/overlays/mipi-panel.dtbo
 RK3326:~ # sync; mount -o remount,ro /flash/
 ```
 Here we just make an overlays directory writable, then call a script that does all the importing stuff.  

--- a/docs/devices/unbranded/game-console-r36max.md
+++ b/docs/devices/unbranded/game-console-r36max.md
@@ -44,7 +44,7 @@ Assuming you have an [SSH](/faqs/#how-do-i-log-in-over-ssh-or-samba) access and 
 RK3326:~ # mount -o remount,rw /flash
 RK3326:~ # mkdir -p /flash/overlays/
 RK3326:~ # ### Be not afraid! importpanel.py may run for a minute or two for some panels
-RK3326:~ # /usr/libexec/generic-dsi/importpanel.py rf3536k4ka.dtb -O /flash/overlays/mipi-panel.dtbo
+RK3326:~ # /usr/libexec/generic-dsi/importpanel.py rf3536k4ka.dtb -O dtbo -o /flash/overlays/mipi-panel.dtbo
 RK3326:~ # sync; mount -o remount,ro /flash/
 ```
 Here we just make an overlays directory writable, then call a script that does all the importing stuff.  


### PR DESCRIPTION
Earlier I changed `importpanel.py` options to be more consistent with dtc.  
Here I update the docs accordingly.