### PR TITLE
Suggested improvements to the HDMI configure page

### DIFF
--- a/docs/configure/hdmi.md
+++ b/docs/configure/hdmi.md
@@ -6,7 +6,7 @@ If your device supports HDMI, you should try to connect it to an HDMI display be
 
 BEAR IN MIND that some devices may connect better with an HDMI display if the display is plugged into the device BEFORE the device is turned on, instead of after the device is turned on
 
-Below is how to set the output resolution (eg to 1280x720) on the external display automatically on boot using the sway compositor. These directions assume that you have used [ssh to connect to the device](configure/cloud-sync/#step-1-enable-network-and-ssh-access). Alternatively you can remove the SD card, connect it to a computer and perform these same operations in a linux terminal, but you may need to type "sudo " before each command and put in the root password on your computer.
+Below is how to set the output resolution (eg to 1280x720) on the external display automatically on boot using the sway compositor. These directions assume that you have used [ssh to connect to the device](https://rocknix.org/configure/cloud-sync/#step-1-enable-network-and-ssh-access). Alternatively you can remove the SD card, connect it to a computer and perform these same operations in a linux terminal, but you may need to type "sudo " before each command and put in the root password on your computer.
 
 Create autostart script:
 ```

--- a/docs/configure/hdmi.md
+++ b/docs/configure/hdmi.md
@@ -6,7 +6,7 @@ If your device supports HDMI, you should try to connect it to an HDMI display be
 
 BEAR IN MIND that some devices may connect better with an HDMI display if the display is plugged into the device BEFORE the device is turned on, instead of after the device is turned on
 
-Below is how to set the output resolution (eg to 1280x720) on the external display automatically on boot using the sway compositor. These directions assume that you have used [ssh to connect to the device](https://rocknix.org/configure/cloud-sync/#step-1-enable-network-and-ssh-access). Alternatively you can remove the SD card, connect it to a computer and perform the operations below in a linux terminal, but you may need to type "sudo " before each command and put in the root password on your computer or else you will get a "Permission denied" error
+Below is how to set the output resolution (eg to 1280x720) on the external display automatically on boot using the sway compositor. These directions assume that you have used [ssh to connect to the device](https://rocknix.org/configure/cloud-sync/#step-1-enable-network-and-ssh-access). Alternatively you can remove the SD card, connect it to a computer and perform the operations below in a linux terminal, but you may need to type "sudo " before each command and put in the root password on your computer when prompted or else you will get a "Permission denied" error
 
 Create autostart script:
 ```

--- a/docs/configure/hdmi.md
+++ b/docs/configure/hdmi.md
@@ -2,9 +2,9 @@
 
 Some devices support HDMI output to an external display.
 
-If your device supports HDMI, you should try to connect it to an HDMI display before following any other directions on this page. Configuring the HDMI display may not be necessary.
+If your device supports HDMI, you should try to connect it to an HDMI display before following any other directions on this page. Configuring the HDMI display (as described below) may not be necessary.
 
-BEAR IN MIND that some devices may connect better with an HDMI display if the display is plugged into the device BEFORE the device is turned on
+BEAR IN MIND that some devices may connect better with an HDMI display if the display is plugged into the device BEFORE the device is turned on, instead of after the device is turned on
 
 Below is how to set the output resolution (eg to 1280x720) on the external display automatically on boot using the sway compositor. These directions assume that you have used ssh to connect to the device. Alternatively you can remove the SD card, connect it to a computer and perform these same operations in a linux terminal, but you may need to type "sudo " before each command and put in the root password on your computer.
 

--- a/docs/configure/hdmi.md
+++ b/docs/configure/hdmi.md
@@ -2,7 +2,11 @@
 
 Some devices support HDMI output to an external display.
 
-To set the output resolution (eg to 1280x720) automatically on boot on a build using the sway compositor: 
+If your device supports HDMI, you should try to connect it to an HDMI display before following any other directions on this page. Configuring the HDMI display may not be necessary.
+
+BEAR IN MIND that some devices may connect better with an HDMI display if the display is plugged into the device BEFORE the device is turned on
+
+Below is how to set the output resolution (eg to 1280x720) on the external display automatically on boot using the sway compositor. These directions assume that you have used ssh to connect to the device. Alternatively you can remove the SD card, connect it to a computer and perform these same operations in a linux terminal, but you may need to type "sudo " before each command and put in the root password on your computer.
 
 Create autostart script:
 ```
@@ -19,4 +23,13 @@ echo "output HDMI-A-1 resolution 1280x720" >> /storage/.config/sway/config
 Make the script executable:
 ```
 chmod +x /storage/.config/autostart/090-sway-hdmi-resolution
+```
+
+Optional: Force position to be 0 0
+
+If you are still having trouble getting the external display to work correctly, you can force the external screen to mirror the device screen by following the above directions but instead using the code below in 090-sway-hdmi-resolution 
+
+```
+#!/bin/bash
+echo "output HDMI-A-1 resolution 1280x720 position 0 0" >> /storage/.config/sway/config
 ```

--- a/docs/configure/hdmi.md
+++ b/docs/configure/hdmi.md
@@ -6,7 +6,7 @@ If your device supports HDMI, you should try to connect it to an HDMI display be
 
 BEAR IN MIND that some devices may connect better with an HDMI display if the display is plugged into the device BEFORE the device is turned on, instead of after the device is turned on
 
-Below is how to set the output resolution (eg to 1280x720) on the external display automatically on boot using the sway compositor. These directions assume that you have used ssh to connect to the device. Alternatively you can remove the SD card, connect it to a computer and perform these same operations in a linux terminal, but you may need to type "sudo " before each command and put in the root password on your computer.
+Below is how to set the output resolution (eg to 1280x720) on the external display automatically on boot using the sway compositor. These directions assume that you have used [ssh to connect to the device](configure/cloud-sync/#step-1-enable-network-and-ssh-access). Alternatively you can remove the SD card, connect it to a computer and perform these same operations in a linux terminal, but you may need to type "sudo " before each command and put in the root password on your computer.
 
 Create autostart script:
 ```

--- a/docs/configure/hdmi.md
+++ b/docs/configure/hdmi.md
@@ -6,7 +6,7 @@ If your device supports HDMI, you should try to connect it to an HDMI display be
 
 BEAR IN MIND that some devices may connect better with an HDMI display if the display is plugged into the device BEFORE the device is turned on, instead of after the device is turned on
 
-Below is how to set the output resolution (eg to 1280x720) on the external display automatically on boot using the sway compositor. These directions assume that you have used [ssh to connect to the device](https://rocknix.org/configure/cloud-sync/#step-1-enable-network-and-ssh-access). Alternatively you can remove the SD card, connect it to a computer and perform these same operations in a linux terminal, but you may need to type "sudo " before each command and put in the root password on your computer.
+Below is how to set the output resolution (eg to 1280x720) on the external display automatically on boot using the sway compositor. These directions assume that you have used [ssh to connect to the device](https://rocknix.org/configure/cloud-sync/#step-1-enable-network-and-ssh-access). Alternatively you can remove the SD card, connect it to a computer and perform the operations below in a linux terminal, but you may need to type "sudo " before each command and put in the root password on your computer or else you will get a "Permission denied" error
 
 Create autostart script:
 ```


### PR DESCRIPTION
The HDMI configure page was relatively short and not very detailed. I personally spent a lot of time tinkering with my device before I realized that if I just plugged in the HDMI port BEFORE turning the device on, then that can solve a lot of problems.

The changes I made to the HDMI configure page do not make the page especially tuned to a particular device. The advice is still pretty generic in my opinion. The earlier page did not actually mention that it is assumed that the user would ssh into their own system to follow the directions.

I appreciate the time and effort that everyone has put into this project. This is my attempt to give back.