### PR TITLE
Removed BT/WiFi on rg28xx.md

### DIFF
--- a/docs/devices/anbernic/rg28xx.md
+++ b/docs/devices/anbernic/rg28xx.md
@@ -18,8 +18,6 @@
 | Feature&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Notes |
 | -- | -- |
 | :material-harddisk: Storage | ROCKNIX can be run from an SD Card and an second SD card can be used to store games |
-| :material-wifi: Wifi | Can be turned on in Emulation Station under Main Menu > Network Settings |
-| :simple-bluetooth: Bluetooth | Supports bluetooth audio and controllers |
 | :material-lightbulb-on: LED | Supports selecting from a set of colors or turning the power LED off (choice persists through reboots) <br> Does not support other effects. |
 
 ## Controls


### PR DESCRIPTION
There is no BT or WiFi hardware on this device. The software might enable/disable it but it doesn't matter.